### PR TITLE
Don’t forbid recent PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "url": "https://composer-spip.lerebooteux.fr"
     }],
     "require": {
-        "php": "5.3 - 7.1",
+        "php": ">=5.3",
         "spip/composer-installer": "^0.2",
         "spip/cms": "3.1.*",
         "spip/mots": "2.7.*",


### PR DESCRIPTION
This package can’t currently be installed on Debian (Sid/Buster) as is.